### PR TITLE
Remove neomerx dependency check

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 Crud Listener for (rapidly) building CakePHP APIs following the
 [JSON API specification](http://jsonapi.org/).
 
-Full documentation [found here](https://crud-json-api.readthedocs.io/).
+## Documentation
+Documentation [found here](https://crud-json-api.readthedocs.io/).
 
 ## Installation
 

--- a/src/Listener/JsonApiListener.php
+++ b/src/Listener/JsonApiListener.php
@@ -26,13 +26,6 @@ class JsonApiListener extends ApiListener
     use JsonApiTrait;
 
     /**
-     * Required composer package with Crud supported version
-     *
-     * @var string
-     */
-    protected $neomerxPackage = 'neomerx/json-api:^0.8.10';
-
-    /**
      * Default configuration
      *
      * @var array
@@ -114,7 +107,6 @@ class JsonApiListener extends ApiListener
      */
     public function beforeHandle(Event $event)
     {
-        $this->_checkPackageDependencies();
         $this->_checkRequestMethods();
         $this->_validateConfigOptions();
         $this->_checkRequestData();
@@ -437,19 +429,6 @@ class JsonApiListener extends ApiListener
         ]);
 
         return $this->_controller()->render();
-    }
-
-    /**
-     * Make sure the neomerx/json-api composer package is installed
-     *
-     * @throws \Crud\Error\Exception\CrudException
-     * @return void
-     */
-    protected function _checkPackageDependencies()
-    {
-        if (!class_exists('\Neomerx\JsonApi\Encoder\Encoder')) {
-            throw new CrudException('JsonApiListener requires composer installing ' . $this->neomerxPackage);
-        }
     }
 
     /**

--- a/tests/TestCase/Listener/JsonApiListenerTest.php
+++ b/tests/TestCase/Listener/JsonApiListenerTest.php
@@ -482,38 +482,6 @@ class JsonApiListenerTest extends TestCase
     }
 
     /**
-     * Make sure listener continues if neomerx package is installed
-     *
-     * @return void
-     */
-    public function testCheckPackageDependenciesSuccess()
-    {
-        $listener = $this
-            ->getMockBuilder('\CrudJsonApi\Listener\JsonApiListener')
-            ->disableOriginalConstructor()
-            ->setMethods(null)
-            ->getMock();
-
-        $this->assertTrue(class_exists('\Neomerx\JsonApi\Encoder\Encoder'));
-
-        $this->setReflectionClassInstance($listener);
-        $this->callProtectedMethod('_checkPackageDependencies', [], $listener);
-    }
-
-    /**
-     * Make sure listener stops if neomerx package is not installed
-     *
-     * @expectedException \Crud\Error\Exception\CrudException
-     * @expectedExceptionMessage JsonApiListener requires composer installing neomerx/json-api:^0.8.10
-     */
-    public function testCheckPackageDependenciesFail()
-    {
-        $this->markTestIncomplete(
-            'Implement this test to bump coverage to 100%. Requires mocking system/php functions'
-        );
-    }
-
-    /**
      * Make sure config option `withJsonApiVersion` accepts a boolean
      *
      * @return void


### PR DESCRIPTION
We no longer need to check if composer package `neomerx/json-api` is installed since it has become a required dependency.