### PR TITLE
Dasherize attribute keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ matrix:
 before_script:
   - if [[ $TRAVIS_PHP_VERSION != 7.0 ]]; then phpenv config-rm xdebug.ini; fi
 
+  - if [[ $TRAVIS_PHP_VERSION = 5.5 ]]; then composer require --dev friendsofcake/search:^3.0; fi
+  - if [[ $TRAVIS_PHP_VERSION != 5.5 ]]; then composer install --prefer-dist --no-interaction; fi
+
   - composer self-update
   - composer install --prefer-dist --no-interaction
 

--- a/src/Listener/JsonApi/DocumentValidator.php
+++ b/src/Listener/JsonApi/DocumentValidator.php
@@ -5,7 +5,7 @@ use Cake\ORM\Entity;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Cake\Validation\Validation;
-use Crud\Core\Object;
+use Crud\Core\BaseObject;
 use Crud\Error\Exception\CrudException;
 use Crud\Error\Exception\ValidationException;
 use Neomerx\JsonApi\Document\Error;
@@ -20,7 +20,7 @@ use StdClass;
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  */
-class DocumentValidator extends Object
+class DocumentValidator extends BaseObject
 {
     /**
      * RequestHandler decoded JSON API document array.

--- a/src/Listener/JsonApiListener.php
+++ b/src/Listener/JsonApiListener.php
@@ -722,7 +722,19 @@ class JsonApiListener extends ApiListener
 
         if (array_key_exists('attributes', $document['data'])) {
             $result = array_merge_recursive($result, $document['data']['attributes']);
-        };
+
+            // dasherize attribute keys if need be
+            if ($this->config('inflect') === 'dasherize') {
+                foreach ($result as $key => $value) {
+                    $underscoredKey = Inflector::underscore($key);
+
+                    if (!array_key_exists($underscoredKey, $result)) {
+                        $result[$underscoredKey] = $value;
+                        unset($result[$key]);
+                    }
+                }
+            }
+        }
 
         if (!array_key_exists('relationships', $document['data'])) {
             return $result;

--- a/src/Listener/JsonApiListener.php
+++ b/src/Listener/JsonApiListener.php
@@ -40,7 +40,7 @@ class JsonApiListener extends ApiListener
             'message' => 'Unknown error',
             'code' => 0,
         ],
-        'exceptionRenderer' => 'Crud\Error\JsonApiExceptionRenderer',
+        'exceptionRenderer' => 'CrudJsonApi\Error\JsonApiExceptionRenderer',
         'setFlash' => false,
         'withJsonApiVersion' => false, // true or array/hash with additional meta information (will add top-level member `jsonapi` to the response)
         'meta' => [], // array or hash with meta information (will add top-level node `meta` to the response)

--- a/src/Schema/JsonApi/DynamicEntitySchema.php
+++ b/src/Schema/JsonApi/DynamicEntitySchema.php
@@ -114,6 +114,18 @@ class DynamicEntitySchema extends SchemaProvider
             unset($attributes[$propertyName]);
         }
 
+        // dasherize attribute keys (like `created_by`) if need be
+        if ($this->_view->viewVars['_inflect'] === 'dasherize') {
+            foreach ($attributes as $key => $value) {
+                $dasherizedKey = Inflector::dasherize($key);
+
+                if (!array_key_exists($dasherizedKey, $attributes)) {
+                    $attributes[$dasherizedKey] = $value;
+                    unset($attributes[$key]);
+                }
+            }
+        }
+
         return $attributes;
     }
 

--- a/tests/Fixture/CountriesFixture.php
+++ b/tests/Fixture/CountriesFixture.php
@@ -10,13 +10,14 @@ class CountriesFixture extends TestFixture
         'id' => ['type' => 'integer'],
         'code' => ['type' => 'string', 'length' => 2, 'null' => false],
         'name' => ['type' => 'string', 'length' => 255, 'null' => false],
+        'dummy_counter' => ['type' => 'integer'],
         'currency_id' => ['type' => 'integer', 'null' => false],
         'national_capital_id' => ['type' => 'integer', 'null' => false],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];
 
     public $records = [
-        ['code' => 'NL', 'name' => 'The Netherlands', 'currency_id' => 1, 'national_capital_id' => 1],
-        ['code' => 'BE', 'name' => 'Belgium', 'currency_id' => 1, 'national_capital_id' => 2]
+        ['code' => 'NL', 'name' => 'The Netherlands', 'dummy_counter' => 11111, 'currency_id' => 1, 'national_capital_id' => 1],
+        ['code' => 'BE', 'name' => 'Belgium', 'dummy_counter' => 22222, 'currency_id' => 1, 'national_capital_id' => 2]
     ];
 }

--- a/tests/Fixture/CulturesFixture.php
+++ b/tests/Fixture/CulturesFixture.php
@@ -10,13 +10,14 @@ class CulturesFixture extends TestFixture
         'id' => ['type' => 'integer'],
         'code' => ['type' => 'string', 'length' => 5, 'null' => false],
         'name' => ['type' => 'string', 'length' => 100, 'null' => false],
+        'another_dummy_counter' => ['type' => 'integer'],
         'country_id' => ['type' => 'integer', 'null' => false],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];
 
     public $records = [
-        ['code' => 'nl-NL', 'name' => 'Dutch', 'country_id' => 1],
-        ['code' => 'nl-BE', 'name' => 'Dutch (Belgium)', 'country_id' => 2],
-        ['code' => 'fr-BE', 'name' => 'French (Belgium)', 'country_id' => 2],
+        ['code' => 'nl-NL', 'name' => 'Dutch', 'another_dummy_counter' => 11111, 'country_id' => 1],
+        ['code' => 'nl-BE', 'name' => 'Dutch (Belgium)', 'another_dummy_counter' => 22222, 'country_id' => 2],
+        ['code' => 'fr-BE', 'name' => 'French (Belgium)', 'another_dummy_counter' => 22222, 'country_id' => 2],
     ];
 }

--- a/tests/Fixture/JsonApi/default_get_countries_with_pagination.json
+++ b/tests/Fixture/JsonApi/default_get_countries_with_pagination.json
@@ -17,7 +17,8 @@
             "id": "1",
             "attributes": {
                 "code": "NL",
-                "name": "The Netherlands"
+                "name": "The Netherlands",
+                "dummy-counter": 11111
             },
             "links": {
                 "self": "\/countries\/1"
@@ -28,7 +29,8 @@
             "id": "2",
             "attributes": {
                 "code": "BE",
-                "name": "Belgium"
+                "name": "Belgium",
+                "dummy-counter": 22222
             },
             "links": {
                 "self": "\/countries\/2"

--- a/tests/Fixture/JsonApi/get_countries_no_relationships.json
+++ b/tests/Fixture/JsonApi/get_countries_no_relationships.json
@@ -5,7 +5,8 @@
             "id": "1",
             "attributes": {
                 "code": "NL",
-                "name": "The Netherlands"
+                "name": "The Netherlands",
+                "dummy-counter": 11111
             },
             "links": {
                 "self": "\/countries\/1"
@@ -16,7 +17,8 @@
             "id": "2",
             "attributes": {
                 "code": "BE",
-                "name": "Belgium"
+                "name": "Belgium",
+                "dummy-counter": 22222
             },
             "links": {
                 "self": "\/countries\/2"

--- a/tests/Fixture/JsonApi/get_country_include_all_supported_associations.json
+++ b/tests/Fixture/JsonApi/get_country_include_all_supported_associations.json
@@ -4,7 +4,8 @@
         "id": "1",
         "attributes": {
             "code": "NL",
-            "name": "The Netherlands"
+            "name": "The Netherlands",
+            "dummy-counter": 11111
         },
         "relationships": {
             "currency": {
@@ -84,7 +85,8 @@
             "id": "1",
             "attributes": {
                 "code": "nl-NL",
-                "name": "Dutch"
+                "name": "Dutch",
+                "another-dummy-counter": 11111
             },
             "links": {
                 "self": "\/cultures\/1"

--- a/tests/Fixture/JsonApi/get_country_include_culture.json
+++ b/tests/Fixture/JsonApi/get_country_include_culture.json
@@ -4,7 +4,8 @@
         "id": "1",
         "attributes": {
             "code": "NL",
-            "name": "The Netherlands"
+            "name": "The Netherlands",
+            "dummy-counter": 11111
         },
         "relationships": {
             "cultures": {
@@ -29,7 +30,8 @@
             "id": "1",
             "attributes": {
                 "code": "nl-NL",
-                "name": "Dutch"
+                "name": "Dutch",
+                "another-dummy-counter": 11111
             },
             "links": {
                 "self": "\/cultures\/1"

--- a/tests/Fixture/JsonApi/get_country_include_currency.json
+++ b/tests/Fixture/JsonApi/get_country_include_currency.json
@@ -4,7 +4,8 @@
         "id": "1",
         "attributes": {
             "code": "NL",
-            "name": "The Netherlands"
+            "name": "The Netherlands",
+            "dummy-counter": 11111
         },
         "relationships": {
             "currency": {

--- a/tests/Fixture/JsonApi/get_country_include_currency_and_countries.json
+++ b/tests/Fixture/JsonApi/get_country_include_currency_and_countries.json
@@ -4,7 +4,8 @@
         "id": "1",
         "attributes": {
             "code": "NL",
-            "name": "The Netherlands"
+            "name": "The Netherlands",
+            "dummy-counter": 11111
         },
         "relationships": {
             "currency": {
@@ -27,7 +28,8 @@
             "id": "2",
             "attributes": {
                 "code": "BE",
-                "name": "Belgium"
+                "name": "Belgium",
+                "dummy-counter": 22222
             },
             "links": {
                 "self": "\/countries\/2"

--- a/tests/Fixture/JsonApi/get_country_include_currency_and_culture.json
+++ b/tests/Fixture/JsonApi/get_country_include_currency_and_culture.json
@@ -4,7 +4,8 @@
         "id": "1",
         "attributes": {
             "code": "NL",
-            "name": "The Netherlands"
+            "name": "The Netherlands",
+            "dummy-counter": 11111
         },
         "relationships": {
             "currency": {
@@ -49,7 +50,8 @@
             "id": "1",
             "attributes": {
                 "code": "nl-NL",
-                "name": "Dutch"
+                "name": "Dutch",
+                "another-dummy-counter": 11111
             },
             "links": {
                 "self": "\/cultures\/1"

--- a/tests/Fixture/JsonApi/get_country_include_national-capital.json
+++ b/tests/Fixture/JsonApi/get_country_include_national-capital.json
@@ -4,7 +4,8 @@
         "id": "1",
         "attributes": {
             "code": "NL",
-            "name": "The Netherlands"
+            "name": "The Netherlands",
+            "dummy-counter": 11111
         },
         "relationships": {
             "national-capital": {

--- a/tests/Fixture/JsonApi/get_country_include_national-cities.json
+++ b/tests/Fixture/JsonApi/get_country_include_national-cities.json
@@ -4,7 +4,8 @@
         "id": "1",
         "attributes": {
             "code": "NL",
-            "name": "The Netherlands"
+            "name": "The Netherlands",
+            "dummy-counter": 11111
         },
         "relationships": {
             "national-cities": {

--- a/tests/Fixture/JsonApi/get_country_no_relationships.json
+++ b/tests/Fixture/JsonApi/get_country_no_relationships.json
@@ -4,7 +4,8 @@
         "id": "1",
         "attributes": {
             "code": "NL",
-            "name": "The Netherlands"
+            "name": "The Netherlands",
+            "dummy-counter": 11111
         },
         "links": {
             "self": "\/countries\/1"

--- a/tests/Fixture/JsonApi/post_country_multiple_relationships.json
+++ b/tests/Fixture/JsonApi/post_country_multiple_relationships.json
@@ -3,7 +3,8 @@
         "type": "countries",
         "attributes": {
             "code": "NL",
-            "name": "The Netherlands"
+            "name": "The Netherlands",
+            "dummy-counter": 11111
         },
         "relationships": {
             "cultures": {

--- a/tests/Fixture/JsonApi/post_country_no_relationships.json
+++ b/tests/Fixture/JsonApi/post_country_no_relationships.json
@@ -3,7 +3,8 @@
         "type": "countries",
         "attributes": {
             "code": "NL",
-            "name": "The Netherlands"
+            "name": "The Netherlands",
+            "dummy-counter": 11111
         }
     }
 }

--- a/tests/TestCase/Listener/JsonApiListenerTest.php
+++ b/tests/TestCase/Listener/JsonApiListenerTest.php
@@ -51,7 +51,7 @@ class JsonApiListenerTest extends TestCase
                 'message' => 'Unknown error',
                 'code' => 0,
             ],
-            'exceptionRenderer' => 'Crud\Error\JsonApiExceptionRenderer',
+            'exceptionRenderer' => 'CrudJsonApi\Error\JsonApiExceptionRenderer',
             'setFlash' => false,
             'withJsonApiVersion' => false,
             'meta' => [],

--- a/tests/TestCase/Listener/JsonApiListenerTest.php
+++ b/tests/TestCase/Listener/JsonApiListenerTest.php
@@ -1208,7 +1208,8 @@ class JsonApiListenerTest extends TestCase
         $jsonApiArray = json_decode($jsonApiFixture->read(), true);
         $expected = [
             'code' => 'NL',
-            'name' => 'The Netherlands'
+            'name' => 'The Netherlands',
+            'dummy_counter' => 11111
         ];
         $result = $this->callProtectedMethod('_convertJsonApiDocumentArray', [$jsonApiArray], $listener);
         $this->assertSame($expected, $result);
@@ -1219,6 +1220,7 @@ class JsonApiListenerTest extends TestCase
         $expected = [
             'code' => 'NL',
             'name' => 'The Netherlands',
+            'dummy_counter' => 11111,
             'currency_id' => '3'
         ];
         $result = $this->callProtectedMethod('_convertJsonApiDocumentArray', [$jsonApiArray], $listener);
@@ -1232,7 +1234,8 @@ class JsonApiListenerTest extends TestCase
 
         $expected = [
             'code' => 'NL',
-            'name' => 'The Netherlands'
+            'name' => 'The Netherlands',
+            'dummy_counter' => 11111
         ];
         $result = $this->callProtectedMethod('_convertJsonApiDocumentArray', [$jsonApiArray], $listener);
         $this->assertSame($expected, $result);

--- a/tests/TestCase/Schema/DynamicEntitySchemaTest.php
+++ b/tests/TestCase/Schema/DynamicEntitySchemaTest.php
@@ -73,6 +73,7 @@ class DynamicEntitySchemaTest extends TestCase
             ->getMock();
 
         $view->set('_repositories', $repositories);
+        $view->set('_inflect', 'dasherize');
 
         // setup the schema
         $schemaFactoryInterface = $this

--- a/tests/TestCase/View/JsonApiViewTest.php
+++ b/tests/TestCase/View/JsonApiViewTest.php
@@ -400,7 +400,7 @@ class JsonApiViewTest extends TestCase
         ]);
 
         $this->assertSame(
-            '{"data":{"type":"countries","id":"1","attributes":{"code":"NL","name":"The Netherlands"},"links":{"self":"\/countries\/1"}}}',
+            '{"data":{"type":"countries","id":"1","attributes":{"code":"NL","name":"The Netherlands","dummy-counter":11111},"links":{"self":"\/countries\/1"}}}',
             $view->render()
         );
     }


### PR DESCRIPTION
Attribute keys like `created_by` are now dasherized when the listener's `dasherize` configuration option is used. This prevents having to apply [workarounds](https://github.com/emberjs/data/issues/3416#issuecomment-114178259) when using standardized consumers like Ember Data (that expect dashes everywhere).

What does it do:

1. presents CakePHP `created_by` field as JSON API `created-by` attribute
2. transforms incoming/POSTed JSON API `created-by` attribute to CakePHP `created_by` field
