### PR TITLE
Support routes without fallback (Set _method parameter in Router::normalize call)

### DIFF
--- a/src/Listener/PaginationListener.php
+++ b/src/Listener/PaginationListener.php
@@ -82,21 +82,21 @@ class PaginationListener extends BaseListener
             'controller' => $this->_controller()->name,
             'action' => 'index',
             'page' => $pagination['page'],
-            '_method' => $this->_controller()->request->getMethod(),
+            '_method' => $this->_controller()->request->method(),
         ], true);
 
         $first = Router::$routerMethod([
             'controller' => $this->_controller()->name,
             'action' => 'index',
             'page' => 1,
-            '_method' => $this->_controller()->request->getMethod(),
+            '_method' => $this->_controller()->request->method(),
         ], true);
 
         $last = Router::$routerMethod([
             'controller' => $this->_controller()->name,
             'action' => 'index',
             'page' => $pagination['pageCount'],
-            '_method' => $this->_controller()->request->getMethod(),
+            '_method' => $this->_controller()->request->method(),
         ], true);
 
         $prev = null;
@@ -105,7 +105,7 @@ class PaginationListener extends BaseListener
                 'controller' => $this->_controller()->name,
                 'action' => 'index',
                 'page' => $pagination['page'] - 1,
-                '_method' => $this->_controller()->request->getMethod()
+                '_method' => $this->_controller()->request->method(),
             ], true);
         }
 
@@ -115,7 +115,7 @@ class PaginationListener extends BaseListener
                 'controller' => $this->_controller()->name,
                 'action' => 'index',
                 'page' => $pagination['page'] + 1,
-                '_method' => $this->_controller()->request->getMethod(),
+                '_method' => $this->_controller()->request->method(),
             ], true);
         }
 

--- a/src/Listener/PaginationListener.php
+++ b/src/Listener/PaginationListener.php
@@ -81,19 +81,22 @@ class PaginationListener extends BaseListener
         $self = Router::$routerMethod([
             'controller' => $this->_controller()->name,
             'action' => 'index',
-            'page' => $pagination['page']
+            'page' => $pagination['page'],
+            '_method' => $this->_controller()->request->getMethod(),
         ], true);
 
         $first = Router::$routerMethod([
             'controller' => $this->_controller()->name,
             'action' => 'index',
             'page' => 1,
+            '_method' => $this->_controller()->request->getMethod(),
         ], true);
 
         $last = Router::$routerMethod([
             'controller' => $this->_controller()->name,
             'action' => 'index',
-            'page' => $pagination['pageCount']
+            'page' => $pagination['pageCount'],
+            '_method' => $this->_controller()->request->getMethod(),
         ], true);
 
         $prev = null;
@@ -101,7 +104,8 @@ class PaginationListener extends BaseListener
             $prev = Router::$routerMethod([
                 'controller' => $this->_controller()->name,
                 'action' => 'index',
-                'page' => $pagination['page'] - 1
+                'page' => $pagination['page'] - 1,
+                '_method' => $this->_controller()->request->getMethod()
             ], true);
         }
 
@@ -110,7 +114,8 @@ class PaginationListener extends BaseListener
             $next = Router::$routerMethod([
                 'controller' => $this->_controller()->name,
                 'action' => 'index',
-                'page' => $pagination['page'] + 1
+                'page' => $pagination['page'] + 1,
+                '_method' => $this->_controller()->request->getMethod(),
             ], true);
         }
 

--- a/tests/TestCase/Listener/PaginationListenerTest.php
+++ b/tests/TestCase/Listener/PaginationListenerTest.php
@@ -95,7 +95,7 @@ class PaginationListenerTest extends TestCase
      */
     public function testBeforeRender()
     {
-
+        $this->markTestIncomplete('Not implemented yet.');
     }
 
     /**
@@ -106,6 +106,6 @@ class PaginationListenerTest extends TestCase
 
     public function testGetJsonApiPaginationResponse()
     {
-
+        $this->markTestIncomplete('Not implemented yet.');
     }
 }

--- a/tests/TestCase/Listener/PaginationListenerTest.php
+++ b/tests/TestCase/Listener/PaginationListenerTest.php
@@ -1,0 +1,111 @@
+<?php
+namespace CrudJsonApi\Test\TestCase\Listener;
+
+use Cake\Controller\Controller;
+use Cake\Core\Plugin;
+use Cake\Event\Event;
+use Cake\Filesystem\File;
+use Cake\Network\Request;
+use Cake\Network\Response;
+use Cake\ORM\Query;
+use Cake\ORM\TableRegistry;
+use CrudJsonApi\Listener\PaginationListener;
+use CrudJsonApi\Test\App\Model\Entity\Country;
+use Crud\Event\Subject;
+use Crud\TestSuite\TestCase;
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ */
+class PaginationListenerTest extends TestCase
+{
+
+    /**
+     * fixtures property
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.CrudJsonApi.countries',
+        'plugin.CrudJsonApi.cultures',
+        'plugin.CrudJsonApi.currencies',
+        'plugin.CrudJsonApi.national_capitals',
+        'plugin.CrudJsonApi.national_cities',
+    ];
+
+    /**
+     * Test implementedEvents with API request
+     *
+     * @return void
+     */
+    public function testImplementedEvents()
+    {
+        $controller = $this
+            ->getMockBuilder('\Cake\Controller\Controller')
+            ->setMethods(['foobar'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $controller->RequestHandler = $this->getMockBuilder('\Cake\Controller\Component\RequestHandlerComponent')
+            ->setMethods(['config'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $listener = $this
+            ->getMockBuilder('\CrudJsonApi\Listener\JsonApiListener')
+            ->setMethods(['setupDetectors', '_checkRequestType', '_controller'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $listener
+            ->expects($this->at(1))
+            ->method('_checkRequestType')
+            ->will($this->returnValue(false)); // for asserting missing JSON API Accept header
+
+        $listener
+            ->expects($this->at(3))
+            ->method('_checkRequestType')
+            ->will($this->returnValue(true)); // for asserting valid JSON API Accept header
+
+        $listener
+            ->expects($this->once())
+            ->method('_controller')
+            ->will($this->returnValue($controller));
+
+        // assert that listener does nothing if JSON API Accept header is missing
+        $result = $listener->implementedEvents();
+
+        $this->assertNull($result);
+
+        // assert success if a JSON API Accept header is used
+        $result = $listener->implementedEvents();
+
+        $expected = [
+            'Crud.beforeRender' => ['callable' => 'beforeRender', 'priority' => 75]
+        ];
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test beforeRender() method
+     *
+     * @return void
+     */
+    public function testBeforeRender()
+    {
+
+    }
+
+    /**
+     * Test _getJsonApiPaginationResponse() method
+     *
+     * @return void
+     */
+
+    public function testGetJsonApiPaginationResponse()
+    {
+
+    }
+}

--- a/tests/TestCase/Listener/PaginationListenerTest.php
+++ b/tests/TestCase/Listener/PaginationListenerTest.php
@@ -41,51 +41,13 @@ class PaginationListenerTest extends TestCase
      */
     public function testImplementedEvents()
     {
-        $controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
-            ->setMethods(['foobar'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $controller->RequestHandler = $this->getMockBuilder('\Cake\Controller\Component\RequestHandlerComponent')
-            ->setMethods(['config'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $listener = $this
-            ->getMockBuilder('\CrudJsonApi\Listener\JsonApiListener')
-            ->setMethods(['setupDetectors', '_checkRequestType', '_controller'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $listener
-            ->expects($this->at(1))
-            ->method('_checkRequestType')
-            ->will($this->returnValue(false)); // for asserting missing JSON API Accept header
-
-        $listener
-            ->expects($this->at(3))
-            ->method('_checkRequestType')
-            ->will($this->returnValue(true)); // for asserting valid JSON API Accept header
-
-        $listener
-            ->expects($this->once())
-            ->method('_controller')
-            ->will($this->returnValue($controller));
-
-        // assert that listener does nothing if JSON API Accept header is missing
-        $result = $listener->implementedEvents();
-
-        $this->assertNull($result);
-
-        // assert success if a JSON API Accept header is used
-        $result = $listener->implementedEvents();
-
+        /*
         $expected = [
             'Crud.beforeRender' => ['callable' => 'beforeRender', 'priority' => 75]
         ];
 
-        $this->assertSame($expected, $result);
+        $this->assertSame($expected, $result);*/
+        $this->markTestIncomplete('Not implemented yet.');
     }
 
     /**

--- a/tests/TestCase/Listener/PaginationListenerTest.php
+++ b/tests/TestCase/Listener/PaginationListenerTest.php
@@ -41,13 +41,35 @@ class PaginationListenerTest extends TestCase
      */
     public function testImplementedEvents()
     {
-        /*
+        $listener = $this
+            ->getMockBuilder('\CrudJsonApi\Listener\PaginationListener')
+            ->setMethods(['_checkRequestType'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $listener
+            ->expects($this->at(0))
+            ->method('_checkRequestType')
+            ->will($this->returnValue(false)); // for asserting missing JSON API Accept header
+
+        $listener
+            ->expects($this->at(1))
+            ->method('_checkRequestType')
+            ->will($this->returnValue(true)); // for asserting valid JSON API Accept header
+
+        // assert that listener does nothing if JSON API Accept header is missing
+        $result = $listener->implementedEvents();
+
+        $this->assertNull($result);
+
+        // assert success if a JSON API Accept header is used
+        $result = $listener->implementedEvents();
+
         $expected = [
             'Crud.beforeRender' => ['callable' => 'beforeRender', 'priority' => 75]
         ];
 
-        $this->assertSame($expected, $result);*/
-        $this->markTestIncomplete('Not implemented yet.');
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -57,7 +79,39 @@ class PaginationListenerTest extends TestCase
      */
     public function testBeforeRender()
     {
+        $request_null = $this
+            ->getMockBuilder('\Cake\Network\Request')
+            ->setMethods(null)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $request_paging = $this
+            ->getMockBuilder('\Cake\Network\Request')
+            ->setMethods(null)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $controller = $this
+            ->getMockBuilder('\Cake\Controller\Controller')
+            ->setMethods(['set'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $listener = $this
+            ->getMockBuilder('\CrudJsonApi\Listener\PaginationListener')
+            ->setMethods(['_controller', '_request'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $listener
+            ->expects($this->at(0))
+            ->method('_request')
+            ->will($this->returnValue($request_null));
+
+        $listener->beforeRender(new Event('Crud.beforeRender'));
+
         $this->markTestIncomplete('Not implemented yet.');
+
     }
 
     /**


### PR DESCRIPTION
This is in relation to issue [#18](https://github.com/FriendsOfCake/crud-json-api/issues/18)