### PR TITLE
Fix search key for associations

### DIFF
--- a/src/Schema/JsonApi/DynamicEntitySchema.php
+++ b/src/Schema/JsonApi/DynamicEntitySchema.php
@@ -241,7 +241,7 @@ class DynamicEntitySchema extends SchemaProvider
         $url = Router::url($this->_getRepositoryRoutingParameters($relatedRepository) + [
             '_method' => 'GET',
             'action' => 'index',
-            $association->foreignKey() => $entity->id,
+            '?' => [$association->foreignKey() => $entity->id],
         ], $this->_view->viewVars['_absoluteLinks']);
 
         return new Link($url, $meta, $treatAsHref);

--- a/src/Schema/JsonApi/DynamicEntitySchema.php
+++ b/src/Schema/JsonApi/DynamicEntitySchema.php
@@ -238,13 +238,10 @@ class DynamicEntitySchema extends SchemaProvider
             return new Link($url, $meta, $treatAsHref);
         }
 
-        $searchKey = Inflector::tableize($this->_getClassName($entity));
-        $searchKey = Inflector::singularize($searchKey) . '_id';
-
         $url = Router::url($this->_getRepositoryRoutingParameters($relatedRepository) + [
             '_method' => 'GET',
             'action' => 'index',
-            $searchKey => $entity->id,
+            $association->foreignKey() => $entity->id,
         ], $this->_view->viewVars['_absoluteLinks']);
 
         return new Link($url, $meta, $treatAsHref);


### PR DESCRIPTION
Make search key use foreign key instead of singularized entity name.

In my opinion schema should respect changes to table made by user. Singularized entity name is used by default by Cake, but it's not always the use case.