### PR TITLE
Do not break requests adding the debug node

### DIFF
--- a/src/Error/JsonApiExceptionRenderer.php
+++ b/src/Error/JsonApiExceptionRenderer.php
@@ -175,7 +175,16 @@ class JsonApiExceptionRenderer extends ExceptionRenderer
         $result = json_decode($json, true);
         $result['debug'] = $debug;
 
-        return json_encode($result, JSON_PRETTY_PRINT);
+        try {
+            return json_encode($result, JSON_PRETTY_PRINT);
+        } catch (\Exception $e) {
+            $result['debug']['message'] = $e->getMessage();
+            $result['debug']['trace'] = [
+                'error' => 'Unable to encode stack trace',
+            ];
+
+            return json_encode($result, JSON_PRETTY_PRINT);
+        }
     }
 
     /**


### PR DESCRIPTION
Requests which result in an sql error do not return json; instead they
can collapse trying to generate the stack trace example:

```
-> curl -i "http://localhost/some/url"
HTTP/1.1 500 Internal Server Error
...
X-DEBUGKIT-ID: ee398a73-c770-4b7c-b1e0-5b878a8691cf

An Internal Server Error Occurred
```

Excerpt from application logs:

```
[2018-03-22 05:08:57] app.public.default [pid:4749] - ERROR - [PDOException] SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db.foo' doesn't exist Request URL: /some/url
Stack Trace:
#0 /app/vendor/cakephp/cakephp/src/Database/Statement/MysqlStatement.php(39): PDOStatement->execute(NULL)
#1 /app/vendor/cakephp/cakephp/src/Database/Statement/StatementDecorator.php(174): Cake\Database\Statement\MysqlStatement->execute(NULL)
#2 /app/vendor/cakephp/cakephp/src/Database/Log/LoggingStatement.php(56): Cake\Database\Statement\StatementDecorator->execute(NULL)
#3 /app/vendor/cakephp/cakephp/src/Database/Connection.php(315): Cake\Database\Log\LoggingStatement->execute()
#4 /app/vendor/cakephp/cakephp/src/Database/Query.php(214): Cake\Database\Connection->run(Object(Cake\ORM\Query))
#5 /app/vendor/cakephp/cakephp/src/ORM/Query.php(1039): Cake\Database\Query->execute()
#6 /app/vendor/cakephp/cakephp/src/Datasource/QueryTrait.php(287): Cake\ORM\Query->_execute()
#7 /app/vendor/cakephp/cakephp/src/ORM/Query.php(987): Cake\ORM\Query->_all()
#8 /app/vendor/cakephp/cakephp/src/ORM/Query.php(1238): Cake\ORM\Query->all()
#9 [internal function]: Cake\ORM\Query->jsonSerialize()
#10 /app/vendor/friendsofcake/crud-json-api/src/Error/JsonApiExceptionRenderer.php(178): json_encode(Array, 128)
#11 /app/vendor/friendsofcake/crud-json-api/src/Error/JsonApiExceptionRenderer.php(63): CrudJsonApi\Error\JsonApiExceptionRenderer->_addDebugNode('{"errors":[{"co...')
#12 /app/vendor/cakephp/cakephp/src/Error/ExceptionRenderer.php(200): CrudJsonApi\Error\JsonApiExceptionRenderer->_outputMessage('pdo_error')
#13 /app/vendor/cakephp/cakephp/src/Error/Middleware/ErrorHandlerMiddleware.php(118): Cake\Error\ExceptionRenderer->render()
#14 /app/vendor/cakephp/cakephp/src/Error/Middleware/ErrorHandlerMiddleware.php(100): Cake\Error\Middleware\ErrorHandlerMiddleware->handleException(Object(PDOException), Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#15 /app/vendor/cakephp/cakephp/src/Http/Runner.php(65): Cake\Error\Middleware\ErrorHandlerMiddleware->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response), Object(Cake\Http\Runner))
#16 /app/vendor/cakephp/debug_kit/src/Middleware/DebugKitMiddleware.php(52): Cake\Http\Runner->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#17 /app/vendor/cakephp/cakephp/src/Http/Runner.php(65): DebugKit\Middleware\DebugKitMiddleware->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response), Object(Cake\Http\Runner))
#18 /app/vendor/cakephp/cakephp/src/Http/Runner.php(51): Cake\Http\Runner->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#19 /app/vendor/cakephp/cakephp/src/Http/Server.php(81): Cake\Http\Runner->run(Object(Cake\Http\MiddlewareQueue), Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#20 /app/web/index.php(27): Cake\Http\Server->run()
#21 {main}  {"scope":[]} []
```

If this happens, just don't add the stack trace to the response.

```
-> curl -i "http://localhost/some/url"
HTTP/1.1 500 Internal Server Error
...
X-DEBUGKIT-ID: ee398a73-c770-4b7c-b1e0-5b878a8691cf

{
    "errors": [
        {
            "code": "500",
            "title": "Internal Server Error",
            "detail": "SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db.foo' doesn't exist"
        }
    ],
    "debug": {
        "class": "PDOException",
        "trace": {
            "error": "Unable to encode stack trace"
        },
        "message": "SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db.foo' doesn't exist"
    },
    "query": {
        "default": [
```