### PR TITLE
Add integration tests for hasMany relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 [![Build Status](https://img.shields.io/travis/FriendsOfCake/crud-json-api/master.svg?style=flat-square)](https://travis-ci.org/FriendsOfCake/crud-json-api)
 [![Coverage Status](https://img.shields.io/codecov/c/github/FriendsOfCake/crud-json-api.svg?style=flat-square)](https://codecov.io/github/FriendsOfCake/crud-json-api)
-[![Total Downloads](https://img.shields.io/packagist/dt/FriendsOfCake/crud-json-api.svg?style=flat-square)](https://packagist.org/packages/FriendsOfCake/crud-json-api)
 [![PHPStan](https://img.shields.io/badge/PHPStan-enabled-brightgreen.svg?style=flat-square)](https://github.com/phpstan/phpstan)
+[![Total Downloads](https://img.shields.io/packagist/dt/FriendsOfCake/crud-json-api.svg?style=flat-square)](https://packagist.org/packages/FriendsOfCake/crud-json-api)
 [![Latest Stable Version](https://img.shields.io/packagist/v/FriendsOfCake/crud-json-api.svg?style=flat-square)](https://packagist.org/packages/FriendsOfCake/crud-json-api)
 [![Documentation Status](https://readthedocs.org/projects/crud-json-api/badge?style=flat-square)](https://crud-json-api.readthedocs.org)
-
 
 # JSON API Crud Listener for CakePHP
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ composer require friendsofcake/crud-json-api
 
 - standardized API data fetching, data posting and (validation) errors
 - automated handling of complex associations/relationships
-- instant compatibility with JSON API supporting tools like Ember Data
+- instant JSON API backend for tools like Ember Data, React and Vue
 - tons of configurable options to manipulate the generated json
 
 ## Sample output

--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@
 
 # JSON API Crud Listener for CakePHP
 
-Crud Listener for (rapidly) building CakePHP APIs following the
-[JSON API specification](http://jsonapi.org/).
+Crud Listener for (rapidly) building CakePHP APIs following the JSON API specification.
 
-## Documentation
-Documentation [found here](https://crud-json-api.readthedocs.io/).
+[Documentation found here](https://crud-json-api.readthedocs.io/).
 
 ## Installation
 

--- a/docs/api-usage/creating-resources.rst
+++ b/docs/api-usage/creating-resources.rst
@@ -38,8 +38,8 @@ A valid JSON API request body for creating a new Country would look similar to:
     }
   }
 
-The same applies when creating new resources with relationships. For example, the JSON API
-request body for creating a new Country with ``currency_id=1`` would look similar to:
+The same rules apply when you create a new Resource and want to set its ``belongsTo`` relationships.
+For example, the JSON API request body for creating a new Country with ``currency_id=1`` would like:
 
 .. code-block:: json
 
@@ -69,9 +69,16 @@ request body for creating a new Country with ``currency_id=1`` would look simila
 Side-Posting
 ^^^^^^^^^^^^
 
-Side-posting is an often requested feature which would allow creating multiple resources (and/or relationships) using a single POST request.
+Side-posting is an often requested feature which would allow creating multiple Resources (and/or relationships) using a single POST request.
 
 However, this functionality is NOT supported by version 1.0 of the JSON API specification and is therefore NOT supported by crud-json-api.
 
-Work for this feature is in progress and might land in version 1.1 of the specification, more information
-`available here <https://github.com/json-api/json-api/pull/1197>`_.
+In practice this means:
+
+- you will only be able to create Resources with ``belongsTo`` relationships pointing to EXISTING foreign keys
+- crud-json-api will throw a ``BadRequestException`` when it detects attempts to side-post ``hasMany`` relationships
+
+.. note::
+
+  Side-posting might land in version 1.1 of the JSON API specification, more information available in
+  `this Pull Request <https://github.com/json-api/json-api/pull/1197>`_.

--- a/src/Listener/JsonApiListener.php
+++ b/src/Listener/JsonApiListener.php
@@ -976,6 +976,12 @@ class JsonApiListener extends ApiListener
         # decode JSON API to CakePHP array format, then call the action as usual
         $decodedJsonApi = $this->_convertJsonApiDocumentArray($requestData);
 
+        // For PATCH operations the `id` field in the request data MUST match the URL id
+        // because JSON API considers it immutable. https://github.com/json-api/json-api/issues/481
+        if (($requestMethod === 'PATCH') && ($this->_controller()->request->getParam('id') !== $decodedJsonApi['id'])) {
+            throw new BadRequestException("URL id does not match request data id as required for JSON API PATCH actions");
+        }
+
         $this->_controller()->request = $this->_controller()->request->withParsedBody($decodedJsonApi);
     }
 

--- a/src/Schema/JsonApi/DynamicEntitySchema.php
+++ b/src/Schema/JsonApi/DynamicEntitySchema.php
@@ -240,10 +240,16 @@ class DynamicEntitySchema extends SchemaProvider
             return new Link($url, $meta, $treatAsHref);
         }
 
+        // generate the link for hasMany relationship
+        $foreignKey = $association->getForeignKey();
+        if ($this->_view->viewVars['_inflect'] === 'dasherize') {
+            $foreignKey = Inflector::dasherize($foreignKey);
+        }
+
         $url = Router::url($this->_getRepositoryRoutingParameters($relatedRepository) + [
             '_method' => 'GET',
             'action' => 'index',
-            '?' => [$association->getForeignKey() => $entity->id]
+            '?' => [$foreignKey => $entity->id]
         ], $this->_view->viewVars['_absoluteLinks']);
 
         return new Link($url, $meta, $treatAsHref);

--- a/src/View/JsonApiView.php
+++ b/src/View/JsonApiView.php
@@ -124,7 +124,7 @@ class JsonApiView extends View
         }
 
         // All "Schema is not registered for a resource at path 'xyz'" errors
-        // originate from the line below and are caused by the mentioned Table
+        // originate from the line below and are caused by the mentioned Cake Table
         // object not being present in the  `_repositories` viewVar array.
         $schemas = $this->_entitiesToNeoMerxSchema($this->viewVars['_repositories']);
 

--- a/tests/App/Model/Table/NationalCitiesTable.php
+++ b/tests/App/Model/Table/NationalCitiesTable.php
@@ -1,10 +1,22 @@
 <?php
 namespace CrudJsonApi\Test\App\Model\Table;
 
+use Cake\Validation\Validator;
+
 class NationalCitiesTable extends \Cake\ORM\Table
 {
     public function initialize(array $config)
     {
         $this->belongsTo('Countries');
+    }
+
+    // prevent unintentionally creating hasMany records
+    public function validationDefault(Validator $validator)
+    {
+        $validator
+            ->requirePresence('name', 'create')
+            ->notEmpty('name');
+
+        return $validator;
     }
 }

--- a/tests/Fixture/CountriesFixture.php
+++ b/tests/Fixture/CountriesFixture.php
@@ -11,8 +11,8 @@ class CountriesFixture extends TestFixture
         'code' => ['type' => 'string', 'length' => 2, 'null' => false],
         'name' => ['type' => 'string', 'length' => 255, 'null' => false],
         'dummy_counter' => ['type' => 'integer'],
-        'currency_id' => ['type' => 'integer', 'null' => false],
-        'national_capital_id' => ['type' => 'integer', 'null' => false],
+        'currency_id' => ['type' => 'integer', 'null' => true],
+        'national_capital_id' => ['type' => 'integer', 'null' => true],
         'supercountry_id' => ['type' => 'integer', 'null' => true],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];

--- a/tests/Fixture/JsonApiRequestBodies/CreatingResources/create-country-throw-side-posting-exception.json
+++ b/tests/Fixture/JsonApiRequestBodies/CreatingResources/create-country-throw-side-posting-exception.json
@@ -1,0 +1,20 @@
+{
+    "data": {
+        "type": "countries",
+        "attributes": {
+            "code": "MC",
+            "name": "Monaco",
+            "dummy-counter": 66666
+        },
+        "relationships": {
+            "national-cities": {
+                "data": [
+                    {
+                        "type": "national-cities",
+                        "id": "4"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/tests/Fixture/JsonApiResponseBodies/Inclusion/get-country-include-all-supported-associations.json
+++ b/tests/Fixture/JsonApiResponseBodies/Inclusion/get-country-include-all-supported-associations.json
@@ -34,7 +34,7 @@
                     }
                 ],
                 "links": {
-                    "self": "\/cultures?country_id=1"
+                    "self": "\/cultures?country-id=1"
                 }
             },
             "national-cities": {
@@ -57,7 +57,7 @@
                     }
                 ],
                 "links": {
-                    "self": "\/national-cities?country_id=1"
+                    "self": "\/national-cities?country-id=1"
                 }
             }
         },

--- a/tests/Fixture/JsonApiResponseBodies/Inclusion/get-country-include-culture.json
+++ b/tests/Fixture/JsonApiResponseBodies/Inclusion/get-country-include-culture.json
@@ -16,7 +16,7 @@
                     }
                 ],
                 "links": {
-                    "self": "\/cultures?country_id=1"
+                    "self": "\/cultures?country-id=1"
                 }
             }
         },

--- a/tests/Fixture/JsonApiResponseBodies/Inclusion/get-country-include-currency-and-countries.json
+++ b/tests/Fixture/JsonApiResponseBodies/Inclusion/get-country-include-currency-and-countries.json
@@ -87,7 +87,7 @@
                         }
                     ],
                     "links": {
-                        "self": "\/countries?currency_id=1"
+                        "self": "\/countries?currency-id=1"
                     }
                 }
             },

--- a/tests/Fixture/JsonApiResponseBodies/Inclusion/get-country-include-currency-and-culture.json
+++ b/tests/Fixture/JsonApiResponseBodies/Inclusion/get-country-include-currency-and-culture.json
@@ -25,7 +25,7 @@
                     }
                 ],
                 "links": {
-                    "self": "\/cultures?country_id=1"
+                    "self": "\/cultures?country-id=1"
                 }
             }
         },

--- a/tests/Fixture/JsonApiResponseBodies/Inclusion/get-country-include-national-capital-and-national-cities.json
+++ b/tests/Fixture/JsonApiResponseBodies/Inclusion/get-country-include-national-capital-and-national-cities.json
@@ -28,7 +28,7 @@
                     }
                 ],
                 "links": {
-                    "self": "\/national-cities?country_id=1"
+                    "self": "\/national-cities?country-id=1"
                 }
             }
         },

--- a/tests/Fixture/JsonApiResponseBodies/Inclusion/get-country-include-national-cities.json
+++ b/tests/Fixture/JsonApiResponseBodies/Inclusion/get-country-include-national-cities.json
@@ -28,7 +28,7 @@
                     }
                 ],
                 "links": {
-                    "self": "\/national-cities?country_id=1"
+                    "self": "\/national-cities?country-id=1"
                 }
             }
         },

--- a/tests/Fixture/JsonApiResponseBodies/Sorting/get-currencies-and-countries-no-sort.json
+++ b/tests/Fixture/JsonApiResponseBodies/Sorting/get-currencies-and-countries-no-sort.json
@@ -28,7 +28,7 @@
                         }
                     ],
                     "links": {
-                        "self": "\/countries?currency_id=1"
+                        "self": "\/countries?currency-id=1"
                     }
                 }
             },
@@ -52,7 +52,7 @@
                         }
                     ],
                     "links": {
-                        "self": "\/countries?currency_id=2"
+                        "self": "\/countries?currency-id=2"
                     }
                 }
             },

--- a/tests/Fixture/JsonApiResponseBodies/Sorting/get-currency-and-countries-sort-by-code-desc.json
+++ b/tests/Fixture/JsonApiResponseBodies/Sorting/get-currency-and-countries-sort-by-code-desc.json
@@ -27,7 +27,7 @@
                     }
                 ],
                 "links": {
-                    "self": "\/countries?currency_id=1"
+                    "self": "\/countries?currency-id=1"
                 }
             }
         },

--- a/tests/Fixture/JsonApiResponseBodies/Sorting/hasmany-index-with-multi-fields-sorting-with-direction.json
+++ b/tests/Fixture/JsonApiResponseBodies/Sorting/hasmany-index-with-multi-fields-sorting-with-direction.json
@@ -28,7 +28,7 @@
                         }
                     ],
                     "links": {
-                        "self": "\/countries?currency_id=1"
+                        "self": "\/countries?currency-id=1"
                     }
                 }
             },
@@ -52,7 +52,7 @@
                         }
                     ],
                     "links": {
-                        "self": "\/countries?currency_id=2"
+                        "self": "\/countries?currency-id=2"
                     }
                 }
             },

--- a/tests/Fixture/JsonApiResponseBodies/get_supercountry_with_subcountries.json
+++ b/tests/Fixture/JsonApiResponseBodies/get_supercountry_with_subcountries.json
@@ -16,7 +16,7 @@
                     }
                 ],
                 "links": {
-                    "self": "\/sub_countries?supercountry_id=3"
+                    "self": "\/sub_countries?supercountry-id=3"
                 }
             }
         },

--- a/tests/TestCase/Integration/JsonApi/CreatingResourcesIntegrationTest.php
+++ b/tests/TestCase/Integration/JsonApi/CreatingResourcesIntegrationTest.php
@@ -5,6 +5,40 @@ use CrudJsonApi\Test\TestCase\Integration\JsonApiBaseTestCase;
 
 class PostRequestIntegrationTest extends JsonApiBaseTestCase
 {
+
+    /**
+     * Make sure attempts to side-post related (hasMany) records throws an exception.
+     *
+     * @return void
+     */
+    public function testSidePostingException()
+    {
+        $this->configRequest([
+            'headers' => [
+                'Accept' => 'application/vnd.api+json',
+                'Content-Type' => 'application/vnd.api+json'
+            ],
+            'input' => $this->_getJsonApiRequestBody('CreatingResources' . DS . 'create-country-throw-side-posting-exception.json')
+        ]);
+
+        $this->post('/countries');
+        $this->assertResponseCode(400); // bad request
+        $responseBodyArray = json_decode((string)$this->_response->getBody(), true);
+
+        $expectedErrorMessage = [
+            'errors' => [
+                [
+                    'code' => 400,
+                    'title' => 'Bad Request',
+                    'detail' => 'JSON API 1.0 does not support side-posting (hasMany relationship data detected in the request body)'
+                ]
+            ]
+        ];
+
+        $this->assertArraySubset($expectedErrorMessage, $responseBodyArray);
+    }
+
+
     /**
      * PhpUnit Data Provider that will call `testCreateResource()` for every array entry
      * so we can test multiple successful POST requests without repeating ourselves.

--- a/tests/TestCase/Integration/JsonApi/CreatingResourcesIntegrationTest.php
+++ b/tests/TestCase/Integration/JsonApi/CreatingResourcesIntegrationTest.php
@@ -38,7 +38,6 @@ class PostRequestIntegrationTest extends JsonApiBaseTestCase
         $this->assertArraySubset($expectedErrorMessage, $responseBodyArray);
     }
 
-
     /**
      * PhpUnit Data Provider that will call `testCreateResource()` for every array entry
      * so we can test multiple successful POST requests without repeating ourselves.

--- a/tests/TestCase/Listener/JsonApiListenerTest.php
+++ b/tests/TestCase/Listener/JsonApiListenerTest.php
@@ -141,6 +141,7 @@ class JsonApiListenerTest extends TestCase
         $expected = [
             'Crud.beforeHandle' => ['callable' => [$listener, 'beforeHandle'], 'priority' => 10],
             'Crud.setFlash' => ['callable' => [$listener, 'setFlash'], 'priority' => 5],
+            'Crud.beforeSave' => ['callable' => [$this, 'beforeSave'], 'priority' => 20],
             'Crud.afterSave' => ['callable' => [$listener, 'afterSave'], 'priority' => 90],
             'Crud.afterDelete' => ['callable' => [$listener, 'afterDelete'], 'priority' => 90],
             'Crud.beforeRender' => ['callable' => [$listener, 'respond'], 'priority' => 100],

--- a/tests/TestCase/Listener/JsonApiListenerTest.php
+++ b/tests/TestCase/Listener/JsonApiListenerTest.php
@@ -141,7 +141,7 @@ class JsonApiListenerTest extends TestCase
         $expected = [
             'Crud.beforeHandle' => ['callable' => [$listener, 'beforeHandle'], 'priority' => 10],
             'Crud.setFlash' => ['callable' => [$listener, 'setFlash'], 'priority' => 5],
-            'Crud.beforeSave' => ['callable' => [$this, 'beforeSave'], 'priority' => 20],
+            'Crud.beforeSave' => ['callable' => [$listener, 'beforeSave'], 'priority' => 20],
             'Crud.afterSave' => ['callable' => [$listener, 'afterSave'], 'priority' => 90],
             'Crud.afterDelete' => ['callable' => [$listener, 'afterDelete'], 'priority' => 90],
             'Crud.beforeRender' => ['callable' => [$listener, 'respond'], 'priority' => 100],

--- a/tests/TestCase/Schema/DynamicEntitySchemaTest.php
+++ b/tests/TestCase/Schema/DynamicEntitySchemaTest.php
@@ -189,7 +189,7 @@ class DynamicEntitySchemaTest extends TestCase
         $this->assertSame($expected, $this->getProtectedProperty('subHref', $result));
 
         // assert _ getRelationshipSelfLinks() for plural (hasMany)
-        $expected = '/cultures?country_id=2';
+        $expected = '/cultures?country-id=2';
 
         $result = $this->callProtectedMethod('getRelationshipSelfLink', [$entity, 'cultures', null, true], $schema);
         $this->setReflectionClassInstance($result);


### PR DESCRIPTION
- [X] NEW: a BadRequestException is now thrown when executing POST/PATCH requests without request data/body
- [X] NEW: a BadRequestException is now thrown when attempts to side-post are detected (creating multiple resources in a single POST/PATCH request is not supported)
- [X] NEW: a BadRequestException is now thrown when executing a PATCH request with non-matching url-id and request-data-id (since JSON API considers id to be immutable)
- [X] FIXED: `belongsTo` relationships are now updated as expected when PATCHing
- [X] FIXED: the foreign key in the self-links for hasMany relationships now get dasherized as expected