### PR TITLE
Minor refactor of _getJsonApiPaginationResponse

### DIFF
--- a/src/Listener/PaginationListener.php
+++ b/src/Listener/PaginationListener.php
@@ -85,7 +85,7 @@ class PaginationListener extends BaseListener
             'filter' => $request->getQuery('filter'),
         ];
 
-        $fullBase = (bool) $this->_controller()->Crud->getConfig('listeners.jsonApi.absoluteLinks');
+        $fullBase = (bool)$this->_controller()->Crud->getConfig('listeners.jsonApi.absoluteLinks');
 
         $self = Router::url([
             'controller' => $this->_controller()->getName(),

--- a/src/Listener/PaginationListener.php
+++ b/src/Listener/PaginationListener.php
@@ -72,8 +72,6 @@ class PaginationListener extends BaseListener
      */
     protected function _getJsonApiPaginationResponse(array $pagination)
     {
-        $routerMethod = 'normalize'; // produce relative links
-
         $defaultUrl = array_intersect_key($pagination, [
             'sort' => null,
             'page' => null,
@@ -87,49 +85,47 @@ class PaginationListener extends BaseListener
             'filter' => $request->getQuery('filter'),
         ];
 
-        if ($this->_controller()->Crud->getConfig('listeners.jsonApi.absoluteLinks') === true) {
-            $routerMethod = 'url'; // produce absolute links
-        }
+        $fullBase = (bool) $this->_controller()->Crud->getConfig('listeners.jsonApi.absoluteLinks');
 
-        $self = Router::$routerMethod([
+        $self = Router::url([
             'controller' => $this->_controller()->getName(),
             'action' => 'index',
             'page' => $pagination['page'],
             '_method' => 'GET',
-        ] + $defaultUrl, true);
+        ] + $defaultUrl, $fullBase);
 
-        $first = Router::$routerMethod([
+        $first = Router::url([
             'controller' => $this->_controller()->getName(),
             'action' => 'index',
             'page' => 1,
             '_method' => 'GET',
-        ] + $defaultUrl, true);
+        ] + $defaultUrl, $fullBase);
 
-        $last = Router::$routerMethod([
+        $last = Router::url([
             'controller' => $this->_controller()->getName(),
             'action' => 'index',
             'page' => $pagination['pageCount'],
             '_method' => 'GET',
-        ] + $defaultUrl, true);
+        ] + $defaultUrl, $fullBase);
 
         $prev = null;
         if ($pagination['prevPage']) {
-            $prev = Router::$routerMethod([
+            $prev = Router::url([
                 'controller' => $this->_controller()->getName(),
                 'action' => 'index',
                 'page' => $pagination['page'] - 1,
                 '_method' => 'GET',
-            ] + $defaultUrl, true);
+            ] + $defaultUrl, $fullBase);
         }
 
         $next = null;
         if ($pagination['nextPage']) {
-            $next = Router::$routerMethod([
+            $next = Router::url([
                 'controller' => $this->_controller()->getName(),
                 'action' => 'index',
                 'page' => $pagination['page'] + 1,
                 '_method' => 'GET',
-            ] + $defaultUrl, true);
+            ] + $defaultUrl, $fullBase);
         }
 
         return [


### PR DESCRIPTION
The method does not need to be a variable, `url` can also return relative urls.

Some duplication can be removed by making a method to return the url for a given page ala:

```
       ...
       $defaults = ['_method' => 'GET', 'page' => $pagination['page']];
        $generateUrl = function($page = null) use ($defaults, $fullBase) {
            $url = array_filter(['page' => $page] + $defaults);
            return Router::url($url, $fullBase);
        };

        $self = $generateUrl();
        $first = $generateUrl(1);
        $last = $generateUrl($pagination['pageCount']);
        ...
```

Is there a reason not to use the pagination helper? args like "page=1" wouldn't be added unless necessary that way.