### PR TITLE
_getSingleEntity adjusted for null case

### DIFF
--- a/src/Listener/JsonApiListener.php
+++ b/src/Listener/JsonApiListener.php
@@ -470,7 +470,7 @@ class JsonApiListener extends ApiListener
     {
         // could be null for e.g. using integration tests
         if ($fieldSets === null) {
-             return;
+            return;
         }
 
         // format $fieldSets to array acceptable by listener config()
@@ -875,6 +875,12 @@ class JsonApiListener extends ApiListener
         }
 
         if (!empty($subject->entities) && $subject->entities instanceof ResultSet) {
+            if ($subject->entities->first() === null) {
+                $repository = $subject->query->getRepository();
+                $entity = $repository->getEntityClass();
+                return new $entity();
+            }
+
             return $subject->entities->first();
         }
 

--- a/tests/TestCase/Listener/JsonApiListenerTest.php
+++ b/tests/TestCase/Listener/JsonApiListenerTest.php
@@ -855,6 +855,57 @@ class JsonApiListenerTest extends TestCase
         $result = $this->callProtectedMethod('_getSingleEntity', [$subject], $listener);
         $this->assertSame($subject->entity, $result);
     }
+    
+    public function testGetSingleEntityForEmptyResultSet()
+    {
+        $controller = $this
+            ->getMockBuilder(Controller::class)
+            ->onlyMethods([])
+            ->enableOriginalConstructor()
+            ->getMock();
+
+        $listener = $this
+            ->getMockBuilder(JsonApiListener::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['_event'])
+            ->onlyMethods(['_controller'])
+            ->getMock();
+
+        $listener
+            ->method('_controller')
+            ->willReturn($controller);
+
+        $entity = new Entity();
+
+        $subject = $this
+            ->getMockBuilder(Subject::class)
+            ->getMock();
+
+        $subject->entities = $this
+            ->getMockBuilder(ResultSet::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['first'])
+            ->getMock();
+
+        $subject->entities
+            ->method('first')
+            ->willReturn(null);
+
+        $query = $this
+            ->getMockBuilder(Query::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $subject->query = $query;
+        $subject->query
+            ->method('getRepository')
+            ->willReturn(TableRegistry::get('Countries'));
+
+        $this->setReflectionClassInstance($listener);
+        $result = $this->callProtectedMethod('_getSingleEntity', [$subject], $listener);
+       
+        $this->assertInstanceOf('Cake\ORM\Entity', $result);
+    }
 
     /**
      * Make sure associations not present in the find result are stripped


### PR DESCRIPTION
The problem was that e.g. for an empty table, the `->first()` call would return null, causing an _getSingleEntity to return null instead of an entity object, which caused an error to be thrown because `_extractEntityAssociations` expects an entity to be passed in.

See: https://github.com/FriendsOfCake/crud-json-api/issues/108