### PR TITLE
Do not inflect properties when it starts with `_`

### DIFF
--- a/src/Schema/JsonApi/DynamicEntitySchema.php
+++ b/src/Schema/JsonApi/DynamicEntitySchema.php
@@ -175,7 +175,7 @@ class DynamicEntitySchema extends BaseSchema
 
         // inflect attribute keys (like `created_by`)
         foreach ($attributes as $key => $value) {
-            $inflectedKey = $this->inflect($this->view, $key);
+            $inflectedKey = $key[0] === '_' ? $key : $this->inflect($this->view, $key);
 
             if (!array_key_exists($inflectedKey, $attributes)) {
                 unset($attributes[$key]);
@@ -218,7 +218,7 @@ class DynamicEntitySchema extends BaseSchema
             }
 
             // inflect related data in entity if need be
-            $inflectedProperty = $this->inflect($this->view, $property);
+            $inflectedProperty = $property[0] === '_' ? $property : $this->inflect($this->view, $property);
 
             if (empty($resource->$inflectedProperty)) {
                 $resource->$inflectedProperty = $resource->$property;

--- a/src/Schema/JsonApi/DynamicEntitySchema.php
+++ b/src/Schema/JsonApi/DynamicEntitySchema.php
@@ -127,7 +127,7 @@ class DynamicEntitySchema extends BaseSchema
             ? $entity->getVisible()
             : $entity->visibleProperties();
         foreach ($properties as $property) {
-            if ($property === '_joinData' || $property === '_matchingData') {
+            if ($property[0] === '_') {
                 continue;
             }
 

--- a/src/Schema/JsonApi/DynamicEntitySchema.php
+++ b/src/Schema/JsonApi/DynamicEntitySchema.php
@@ -323,7 +323,7 @@ class DynamicEntitySchema extends BaseSchema
     {
         $association = $this->getAssociationByProperty($name);
         if (!$association) {
-            throw new InvalidArgumentException('Invalid association ' . $name);
+            throw new InvalidArgumentException(sprintf('Invalid association for resource %s: %s', get_class($resource), $name));
         }
 
         $from = $this->getRepository()

--- a/src/Schema/JsonApi/DynamicEntitySchema.php
+++ b/src/Schema/JsonApi/DynamicEntitySchema.php
@@ -175,7 +175,7 @@ class DynamicEntitySchema extends BaseSchema
 
         // inflect attribute keys (like `created_by`)
         foreach ($attributes as $key => $value) {
-            $inflectedKey = $key[0] === '_' ? $key : $this->inflect($this->view, $key);
+            $inflectedKey = is_numeric($key) || $key[0] === '_' ? $key : $this->inflect($this->view, $key);
 
             if (!array_key_exists($inflectedKey, $attributes)) {
                 unset($attributes[$key]);
@@ -323,7 +323,9 @@ class DynamicEntitySchema extends BaseSchema
     {
         $association = $this->getAssociationByProperty($name);
         if (!$association) {
-            throw new InvalidArgumentException(sprintf('Invalid association for resource %s: %s', get_class($resource), $name));
+            throw new InvalidArgumentException(
+                sprintf('Invalid association for resource %s: %s', get_class($resource), $name)
+            );
         }
 
         $from = $this->getRepository()


### PR DESCRIPTION
Trying to support i18n in an api, any thoughts on how to solve this error: Entity classes must not be the generic "Cake\ORM\Entity" class for repository "Nodes_title_translation" in vendor/friendsofcake/crud-json-api/src/View/JsonApiView.php on line 281
I created custom table and entities, so the above is circumvented

Then it failed with Invalid association `i18n` in vendor/friendsofcake/crud-json-api/src/Schema/JsonApi/DynamicEntitySchema.php on line 3xx.  I wasn't sure where that `i18n` came from. but after a bit of digging around, crud-json-api inflects `_i18n` to `i18n` configured here: https://github.com/cakephp/cakephp/blob/master/src/ORM/Behavior/Translate/EavStrategy.php#L149

This patch skip inflection when a property starts with `_` underscore as it usually used to indicate a system/internal use property.