### PR TITLE
Removed lies ;)

### DIFF
--- a/docs/api-usage-advanced/filtering.rst
+++ b/docs/api-usage-advanced/filtering.rst
@@ -29,8 +29,3 @@ Once that is done you will be able to search your API using URLs similar to:
 
 - ``/countries?filter=netherlands``
 - ``/countries?filter=nether``
-
-Please note that the following search requests would also be matched:
-
-- ``/countries?filter[id]=1``
-- ``/countries?filter[id][]=1&filter[id][]=2``


### PR DESCRIPTION
The documents state that query string arrays will trigger the search manager, but I've tested it and they won't. Also had a second person check it.