### PR TITLE
Clean Up Code Examples

### DIFF
--- a/docs/api-usage-advanced/filtering.rst
+++ b/docs/api-usage-advanced/filtering.rst
@@ -15,14 +15,14 @@ Now create search aliases named ``filter`` in your tables like shown below:
 
   public function searchManager()
   {
-    $searchManager = $this->behaviors()->Search->searchManager();
-    $searchManager->like('filter', [
-      'before' => true,
-      'after' => true,
-      'field' => [$this->aliasField('name')]
-    ]);
+      $searchManager = $this->behaviors()->Search->searchManager();
+      $searchManager->like('filter', [
+          'before' => true,
+          'after' => true,
+          'field' => [$this->aliasField('name')],
+      ]);
 
-    return $searchManager;
+      return $searchManager;
   }
 
 Once that is done you will be able to search your API using URLs similar to:

--- a/docs/api-usage-advanced/inclusion.rst
+++ b/docs/api-usage-advanced/inclusion.rst
@@ -16,14 +16,14 @@ and a ``hasMany`` relationship with Cultures:
 
   public function view()
   {
-    $this->Crud->on('beforeFind', function (Event $event) {
-      $event->getSubject()->query->contain([
-        'Currencies',
-        'Cultures',
-      ]);
-    });
+      $this->Crud->on('beforeFind', function (Event $event) {
+          $event->getSubject()->query->contain([
+              'Currencies',
+              'Cultures',
+          ]);
+      });
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }
 
 Assuming a successful find the listener would produce the
@@ -130,11 +130,11 @@ This is done using the listener configuration:
 
   public function view()
   {
-    $this->Crud
-      ->listener('jsonApi')
-      ->config('queryParameters.include.allowList', ['cultures', 'cities']);
+      $this->Crud
+          ->listener('jsonApi')
+          ->config('queryParameters.include.allowList', ['cultures', 'cities']);
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }
 
 allowListing will prevent all non-allowListed associations from being
@@ -148,9 +148,9 @@ config option to ``true``:
 
   public function view()
   {
-    $this->Crud
-      ->listener('jsonApi')
-      ->config('queryParameters.include.denyList', true);
+      $this->Crud
+          ->listener('jsonApi')
+          ->config('queryParameters.include.denyList', true);
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }

--- a/docs/listener-configuration/listener-options.rst
+++ b/docs/listener-configuration/listener-options.rst
@@ -87,11 +87,11 @@ to manipulate the generated json response. For example:
 
   public function initialize()
   {
-    parent::initialize();
-    $this->Crud->config('listeners.jsonApi.jsonOptions', [
-      JSON_HEX_QUOT,
-      JSON_UNESCAPED_UNICODE,
-    ]);
+      parent::initialize();
+      $this->Crud->config('listeners.jsonApi.jsonOptions', [
+          JSON_HEX_QUOT,
+          JSON_UNESCAPED_UNICODE,
+      ]);
   }
 
 include
@@ -109,8 +109,8 @@ Please note that entity names:
 .. code-block:: phpinline
 
   $this->Crud->config('listeners.jsonApi.include', [
-    'currency', // belongsTo relationship and thus singular
-    'cultures' // hasMany relationship and thus plural
+      'currency', // belongsTo relationship and thus singular
+      'cultures', // hasMany relationship and thus plural
   ]);
 
 .. note::
@@ -128,12 +128,12 @@ generated json. For example:
 .. code-block:: phpinline
 
   $this->Crud->config('listeners.jsonApi.fieldSets', [
-    'countries' => [ // main record
-      'name'
-    ],
-    'currencies' => [ // associated data
-      'code'
-    ]
+      'countries' => [ // main record
+          'name',
+      ],
+      'currencies' => [ // associated data
+          'code',
+      ],
   ]);
 
 .. note::
@@ -181,7 +181,7 @@ by specifying a callable.
 .. code-block:: phpinline
 
   $this->Crud->listener('jsonApi')->config('queryParameter.parent', [
-    'callable' => function ($queryData, $subject) {
-      $subject->query->where('parent' => $queryData);
-    }
+      'callable' => function ($queryData, $subject) {
+          $subject->query->where('parent' => $queryData);
+      },
   ]);

--- a/docs/listener-configuration/pagination.rst
+++ b/docs/listener-configuration/pagination.rst
@@ -9,36 +9,36 @@ it to all controllers, application wide.
 
 .. code-block:: php
 
-  <?php
-  class AppController extends Controller {
-
-    public function initialize()
-    {
-      $this->loadComponent('RequestHandler');
-      $this->loadComponent('Crud.Crud', [
-        'actions' => [
-          'Crud.Index',
-          'Crud.View'
-        ],
-        'listeners' => [
-          'CrudJsonApi.JsonApi',
-          'CrudJsonApi.Pagination',
-        ]
-      ]);
-    }
+  class AppController extends Controller
+  {
+      public function initialize()
+      {
+          $this->loadComponent('RequestHandler');
+          $this->loadComponent('Crud.Crud', [
+              'actions' => [
+                'Crud.Index',
+                'Crud.View',
+              ],
+              'listeners' => [
+                'CrudJsonApi.JsonApi',
+                'CrudJsonApi.Pagination',
+              ],
+          ]);
+      }
+  }
 
 Alternatively, attach the listener to your controllers ``beforeFilter``
 if you prefer attaching the listener to only specific controllers on the fly.
 
 .. code-block:: php
 
-  <?php
-  class SamplesController extends AppController {
-
-    public function beforeFilter(\Cake\Event\Event $event) {
-      parent::beforeFilter();
-      $this->Crud->addListener('CrudJsonApi.Pagination');
-    }
+  class SamplesController extends AppController
+  {
+      public function beforeFilter(\Cake\Event\EventInterface $event)
+      {
+          parent::beforeFilter($event);
+          $this->Crud->addListener('CrudJsonApi.Pagination');
+      }
   }
 
 All ``GET`` requests to the index action will now add

--- a/docs/listener-configuration/schemas.rst
+++ b/docs/listener-configuration/schemas.rst
@@ -31,17 +31,16 @@ file looking similar to:
 
 .. code-block:: phpinline
 
-  <?php
   namespace App\Schema\JsonApi;
 
   use CrudJsonApi\Schema\JsonApi\DynamicEntitySchema;
 
   class CountrySchema extends DynamicEntitySchema
   {
-    public function getSelfSubUrl($entity = null)
-    {
-      return 'http://prefix.only/countries/controller/self-links/';
-    }
+      public function getSelfSubUrl($entity = null)
+      {
+          return 'https://countryies.example.com/controller/self-links/';
+      }
   }
 
 Custom dynamic schema
@@ -55,15 +54,14 @@ a ``src/Schema/JsonApi/DynamicEntitySchema.php`` file looking similar to:
 
 .. code-block:: phpinline
 
-  <?php
   namespace App\Schema\JsonApi;
 
   use CrudJsonApi\Schema\JsonApi\DynamicEntitySchema as CrudDynamicEntitySchema;
 
   class DynamicEntitySchema extends CrudDynamicEntitySchema
   {
-    public function getSelfSubUrl($entity = null)
-    {
-      return 'http://prefix.all/controller/self-links/';
-    }
+      public function getSelfSubUrl($entity = null)
+      {
+          return 'https://api.example.com/controller/self-links/';
+      }
   }

--- a/docs/preface/setup.rst
+++ b/docs/preface/setup.rst
@@ -71,33 +71,32 @@ is loaded **before** ``Crud``.
 
 .. code-block:: php
 
-  <?php
-  class AppController extends Controller {
-
-    public function initialize()
-    {
-      $this->loadComponent('RequestHandler');
-      $this->loadComponent('Crud.Crud', [
-        'actions' => [
-          'Crud.Index',
-          'Crud.View'
-        ],
-        'listeners' => ['CrudJsonApi.JsonApi']
-      ]);
-    }
+  class AppController extends Controller
+  {
+      public function initialize()
+      {
+          $this->loadComponent('RequestHandler');
+          $this->loadComponent('Crud.Crud', [
+              'actions' => [
+                  'Crud.Index',
+                  'Crud.View',
+              ],
+              'listeners' => ['CrudJsonApi.JsonApi'],
+          ]);
+      }
+  }
 
 Alternatively, attach the listener to your controllers ``beforeFilter``
 if you prefer attaching the listener to only specific controllers on the fly.
 
 .. code-block:: php
 
-  <?php
-  class SamplesController extends AppController {
-
-    public function beforeFilter(\Cake\Event\Event $event) {
-      parent::beforeFilter();
-      $this->Crud->addListener('CrudJsonApi.JsonApi');
-    }
+  class SamplesController extends AppController
+  {
+      public function beforeFilter(\Cake\Event\Event $event) {
+          parent::beforeFilter();
+          $this->Crud->addListener('CrudJsonApi.JsonApi');
+      }
   }
 
 Exception Handler
@@ -112,14 +111,13 @@ class and enabling it with the ``exceptionRenderer`` configuration option.
 
 .. code-block:: php
 
-  <?php
-  class AppController extends Controller {
-
-    public function initialize()
-    {
-      parent::initialize();
-      $this->Crud->config(['listeners.jsonApi.exceptionRenderer' => 'App\Error\JsonApiExceptionRenderer']);
-    }
+  class AppController extends Controller
+  {
+      public function initialize()
+      {
+          parent::initialize();
+          $this->Crud->config(['listeners.jsonApi.exceptionRenderer' => 'App\Error\JsonApiExceptionRenderer']);
+      }
   }
 
 .. note::
@@ -150,16 +148,16 @@ to configure your global routing scope in ``config/routes.php`` similar to:
 .. code-block:: phpinline
 
   const API_RESOURCES = [
-    'Countries',
-    'Currencies'
+      'Countries',
+      'Currencies',
   ];
 
   Router::scope('/', function ($routes) {
-    foreach (API_RESOURCES as $apiResource) {
-        $routes->resources($apiResource, [
-            'inflect' => 'dasherize'
-        ]);
-    }
+      foreach (API_RESOURCES as $apiResource) {
+          $routes->resources($apiResource, [
+              'inflect' => 'dasherize',
+          ]);
+      }
   });
 
 Request detector
@@ -173,7 +171,7 @@ and can be used like this inside your application:
 .. code-block:: php
 
   if ($this->request->is('jsonapi')) {
-    return('cool, using JSON API');
+      return 'cool, using JSON API';
   }
 
 .. note::


### PR DESCRIPTION
Clean up the code by using 4 spaces in examples. Add trailing commas in case more code is added (and to help anyone copy/pasting it).